### PR TITLE
Fix timeouts on reconfiguration

### DIFF
--- a/component-petclinic.yml
+++ b/component-petclinic.yml
@@ -184,7 +184,7 @@ application:
                   - deploy-libs:
                       action: serviceCall
                       phase: deploy-libs
-                      precedingPhases: [ get-env-props ]
+                      precedingPhases: [ get-env-props, build-app ]
                       parameters:
                         timeout: 300
                         service: app-manage
@@ -286,7 +286,7 @@ application:
                   - deploy-libs:
                       action: serviceCall
                       phase: deploy-libs
-                      precedingPhases: [ get-env-props ]
+                      precedingPhases: [ get-env-props, build-app ]
                       parameters:
                         timeout: 300
                         service: app-manage
@@ -368,7 +368,7 @@ application:
                   - deploy-libs:
                       action: serviceCall
                       phase: deploy-libs
-                      precedingPhases: [ get-env-props ]
+                      precedingPhases: [ get-env-props, build-app ]
                       parameters:
                         timeout: 300
                         service: app-manage


### PR DESCRIPTION
First commit is just warning fix, most valuable is second one.

Because `workflow.Instance` are executing commands one-by-one, `app` component can not execute `serviceCall` requests from `main` in parallel.

Steps  `build-app` and `deploy-libs` don't depend on each other, so they are started by workflow engine in parallel, but are queued for execution by `app` component, and it is possible for `build-app` to run on `app` component before `deploy-libs`. Because `build-app` can run longer than `deploy-libs`, latter step will time out and fail workflow execution.
